### PR TITLE
Fix base layout closing tags

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -33,19 +33,18 @@
   </header>
   <br><br><br><br>
   <main class="col-md-9 col-xl-8 py-md-3 pl-md-5 bd-content">
-</nav>
     {{ with .Title }}
       <h1>{{ . }}</h1>
     {{ end }}
     {{ block "main" . }}
     {{ end }}
   </main>
-</div></body>
-
   <footer class="text-muted small text-center p-3">
 <hr>
 <img src="../favicon.png" height="20"> Nettsiden er utviklet av <a href="https://petter.dog/">Petter Dog Holstad</a> og <a href="https://stigjohan.no/">Stig Johan Berggren</a>.
 <a href="../kontaktinfo">Kontakt meg.</a>
 </footer>
+
+</body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove stray closing tags from base layout
- keep footer inside `<body>` and close the document cleanly

## Testing
- `hugo` *(fails: command not found)*
- `npx markdownlint README.md` *(fails: 403 Forbidden fetching package)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ac5e94e083229e5a76fc358df0ec