### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ som genereres. For å unngå for mange hugo-commits, bruker vi
 før vi commiter.
 
 *Hugo validator er foreløpig deaktivert grunnet en uløselig konflikt i pull
-request #44. Denne aktivseres på et senere tidspunkt*.
+request #44. Denne aktiveres på et senere tidspunkt*.


### PR DESCRIPTION
## Summary
- fix typo in README: "aktivseres" -> "aktiveres"

## Testing
- `hugo --version` (command not found)
- `npm test` (fails: package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_68a1b574f1c48322b59c2f7cb2daefa7