### PR TITLE
Use valid span element and modern clipboard API

### DIFF
--- a/layouts/shortcodes/copy.html
+++ b/layouts/shortcodes/copy.html
@@ -1,5 +1,5 @@
-<text id="{{ .Get "ident" }}">
-<div style="display:none;">{{ .Get "hiddentext" }}</div></text>
+<span id="{{ .Get "ident" }}">
+<span style="display:none;">{{ .Get "hiddentext" }}</span></span>
 
 {{ .Inner }} <button class="btn badge badge-light" onclick="copyToClipboard('#{{ .Get "ident" }}')">Kopier</button>
 
@@ -8,7 +8,7 @@ function copyToClipboard(element) {
   var $temp = $("<input>");
   $("body").append($temp);
   $temp.val($(element).text()).select();
-  document.execCommand("copy");
+  navigator.clipboard.writeText($temp.val());
   $temp.remove();
 }
 </script>


### PR DESCRIPTION
## Summary
- replace deprecated `<text>` element with `<span>` in `copy` shortcode
- swap `document.execCommand("copy")` for `navigator.clipboard.writeText`

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b56211888322ac9aa1636194b1e4