### PR TITLE
Add collapse arrow shortcode and test

### DIFF
--- a/layouts/shortcodes/collapse-arrow.html
+++ b/layouts/shortcodes/collapse-arrow.html
@@ -1,0 +1,26 @@
+{{/* collapse-arrow shortcode: usage {{< collapse-arrow id="unique" label="Text" >}}Inner{{< /collapse-arrow >}} */}}
+{{ $id := .Get "id" | default (printf "collapse-%d" .Ordinal) }}
+<p>
+  <a href="#{{$id}}" class="text-primary" data-toggle="collapse" aria-expanded="false" aria-controls="{{$id}}">
+    <i class="fas fa-arrow-right" id="{{$id}}-icon"></i> {{ .Get "label" }}
+  </a>
+</p>
+<div class="collapse" id="{{$id}}">
+  <div class="card card-body">
+    {{ .Inner }}
+  </div>
+</div>
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    var collapseElement = document.getElementById('{{ $id }}');
+    var iconElement = document.getElementById('{{ $id }}-icon');
+    collapseElement.addEventListener('show.bs.collapse', function () {
+      iconElement.classList.remove('fa-arrow-right');
+      iconElement.classList.add('fa-arrow-down');
+    });
+    collapseElement.addEventListener('hide.bs.collapse', function () {
+      iconElement.classList.remove('fa-arrow-down');
+      iconElement.classList.add('fa-arrow-right');
+    });
+  });
+</script>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "pdog.no",
+  "version": "1.0.0",
+  "description": "Hjemmeside for Petter Holstad. <https://pdog.no>",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.43.0"
+  }
+}

--- a/tests/collapse-icon.html
+++ b/tests/collapse-icon.html
@@ -1,47 +1,42 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<!-- Bootstrap CSS -->
-<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.6.0/css/bootstrap.min.css">
-<!-- FontAwesome -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
-<title>Simple Text Collapsible with Arrow</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.6.0/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
+  <title>Collapse Icon Test</title>
 </head>
 <body>
-
 <div class="container mt-3">
-  <!-- Text trigger with arrow -->
   <p>
     <a href="#collapseContent" class="text-primary" data-toggle="collapse" aria-expanded="false" aria-controls="collapseContent">
       <i class="fas fa-arrow-right" id="collapseIcon"></i> Click here to expand/collapse content
     </a>
   </p>
-
-  <!-- Collapsible content -->
   <div class="collapse" id="collapseContent">
     <div class="card card-body">
       This is some collapsible content. Simple and easy to click!
     </div>
   </div>
 </div>
-
-<!-- Bootstrap and necessary dependencies -->
 <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.7.0/dist/popper.min.js"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.6.0/js/bootstrap.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/js/all.min.js"></script>
 <script>
-// Script to change arrow direction on collapse
-$(document).ready(function(){
-  $('#collapseContent').on('show.bs.collapse', function () {
-    $('#collapseIcon').removeClass('fa-arrow-right').addClass('fa-arrow-down');
+  document.addEventListener('DOMContentLoaded', function() {
+    var collapseElement = document.getElementById('collapseContent');
+    var iconElement = document.getElementById('collapseIcon');
+    $('#collapseContent').on('show.bs.collapse', function () {
+      iconElement.classList.remove('fa-arrow-right');
+      iconElement.classList.add('fa-arrow-down');
+    });
+    $('#collapseContent').on('hide.bs.collapse', function () {
+      iconElement.classList.remove('fa-arrow-down');
+      iconElement.classList.add('fa-arrow-right');
+    });
   });
-  $('#collapseContent').on('hide.bs.collapse', function () {
-    $('#collapseIcon').removeClass('fa-arrow-down').addClass('fa-arrow-right');
-  });
-});
 </script>
 </body>
 </html>

--- a/tests/collapse-icon.spec.ts
+++ b/tests/collapse-icon.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const filePath = 'file://' + path.resolve(__dirname, 'collapse-icon.html');
+
+test('icon rotates on collapse toggle', async ({ page }) => {
+  await page.goto(filePath);
+  const icon = page.locator('#collapseIcon');
+
+  // initial state: right arrow
+  await expect(icon).toHaveClass(/fa-arrow-right/);
+
+  // open collapse
+  await page.click('a[data-toggle="collapse"]');
+  await page.waitForSelector('#collapseContent.show');
+  await expect(icon).toHaveClass(/fa-arrow-down/);
+
+  // close collapse
+  await page.click('a[data-toggle="collapse"]');
+  await page.waitForSelector('#collapseContent:not(.show)');
+  await expect(icon).toHaveClass(/fa-arrow-right/);
+});


### PR DESCRIPTION
## Summary
- add `collapse-arrow` shortcode that flips fontawesome arrow on collapse
- move demo into test fixture and add Playwright test verifying icon rotation

## Testing
- `npm test` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b56ca15c832283fb0a344edfd727